### PR TITLE
Cleanup of sphinx-build leftovers from example-ui

### DIFF
--- a/example-ui.spec
+++ b/example-ui.spec
@@ -56,6 +56,8 @@ django-admin compilemessages
 popd
 # Build html documentation
 sphinx-build doc/source html
+# remove the sphinx-build leftovers
+rm -rf html/.{doctrees,buildinfo}
 
 %install
 %py2_install


### PR DESCRIPTION
Directories .doctrees and .buildinfo must be removed after
building the documentation with sphinx-build.
