### PR TITLE
Add i18n to python-example-library.spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is a set of example files that can be use to create rpm packages for openst
 
 - puppet-example.spec: file is only for reference. In RDO, spec files are created automatically from metadata.json file.
 - python-exampleclient: all required content for executable included in RPMs has been commented as most clients should be provided as osc plugins for openstackclient. For client packages including executable files, read the spec file and uncomment what needed.
-- spec file for openstack-example includes compilation and installation of translation files. If the project doesn't contain translation files, lines with references to locale or lang mut be removed or commented.
+- spec files for openstack-example, python-example-library and example-ui include compilation and installation of translation files. If the project doesn't contain translation files, lines with references to locale or lang mut be removed or commented.
 - For tests packaging following convention must be followed:
   * python-PROJECT-tests: includes all tests, and would be eventually virtual, requiring subpackages below for backward compatibility with the current state
   * python-PROJECT-tests-unit: includes unit tests and their deps

--- a/python-example-library.spec
+++ b/python-example-library.spec
@@ -34,7 +34,7 @@ BuildRequires:  python-babel
 
 Requires:   python-oslo-config >= 2:3.4.0
 # If translation files exist
-Requires:       python-%{library}-lang >= %{version}-%{release}
+Requires:       python-%{library}-lang = %{version}-%{release}
 
 %description -n python2-%{library}
 OpenStack example library.
@@ -80,7 +80,7 @@ BuildRequires:  git
 
 Requires:   python3-oslo-config >= 2:3.4.0
 # If translation files exist
-Requires:       python-%{library}-lang >= %{version}-%{release}
+Requires:       python-%{library}-lang = %{version}-%{release}
 
 %description -n python3-%{library}
 OpenStack example library.


### PR DESCRIPTION
Added required lines to manage properly translation files if exist in upstream project.
